### PR TITLE
Fix for Magento 2 admin error

### DIFF
--- a/Block/Adminhtml/Order/View/Additional.php
+++ b/Block/Adminhtml/Order/View/Additional.php
@@ -43,13 +43,18 @@ class Additional extends \Magento\Sales\Block\Adminhtml\Order\AbstractOrder
 
         // $logger->info($cus->getId());
 
+        $address = null;
+
         if ($addressType == 'billing') {
-            return $cus->getAddressById($_order->getBillingAddress()->getCustomerAddressId());
+            $address = $_order->getBillingAddress();
         } elseif ($addressType == 'shipping') {
-            return $cus->getAddressById($_order->getShippingAddress()->getCustomerAddressId());
+            $address = $_order->getShippingAddress();
         }
 
-
+        if(!$address){
+            return null;
+        }
+        return $cus->getAddressById($address->getCustomerAddressId());
 
     }
 
@@ -62,6 +67,10 @@ class Additional extends \Magento\Sales\Block\Adminhtml\Order\AbstractOrder
         // $logger->info(print_r( ['Geodemoraphics'], true));
 
         $address = $this->loadOrderAddress($addressType);
+
+        if(!$address){
+            return [];
+        }
 
         $customAttributes = $address->getCustomAttributes();
 


### PR DESCRIPTION
We've seen a bug where loading orders in the Magento 2 admin causes a 500 response.

Example of error log

```
[2024-05-02T12:31:52.649439+00:00] main.CRITICAL: Error: Call to a member function getCustomerAddressId() on null in /var/www/app/code/Afd/Pce/Block/Adminhtml/Order/View/Additional.php:49
Stack trace:
#0 /var/www/app/code/Afd/Pce/Block/Adminhtml/Order/View/Additional.php(64): Afd\Pce\Block\Adminhtml\Order\View\Additional->loadOrderAddress()
#1 /var/www/app/code/Afd/Pce/view/adminhtml/templates/admin_geodemographics.phtml(34): Afd\Pce\Block\Adminhtml\Order\View\Additional->getGeodemographicFields()
#2 /var/www/vendor/magento/framework/View/TemplateEngine/Php.php(71): include('...')
```

This is cause the order only contains virtual products and as such doesn't have a shipping address. So $_order->getShippingAddress() returns null and getCustomerAddressId() is called resulting in the error.

This pull request slightly restructures the loadOrderAddress method to return null early if there is no address. Subsequently getGeodemographicFields will now return an empty array when the address no address is available. 